### PR TITLE
Adequate ESPHome config to the new platform style

### DIFF
--- a/slimmelezer.yaml
+++ b/slimmelezer.yaml
@@ -4,9 +4,6 @@ substitutions:
     
 esphome:
   name: ${device_name}
-  platform: ESP8266
-  esp8266_restore_from_flash: true
-  board: d1_mini
   name_add_mac_suffix: false
   project:
     name: zuidwijk.slimmelezer
@@ -24,7 +21,10 @@ esphome:
             - logger.log:
                 level: info
                 format: "Not using decryption key. If you need to set a key use Home Assistant service 'ESPHome:  ${device_name}_set_dsmr_key'"
-
+esp8266:
+  board: d1_mini
+  restore_from_flash: true
+  
 wifi:
   # remove leading '#' and fill in your wifi details
 #  ssid: !secret wifi_ssid 


### PR DESCRIPTION
The latest version of ESPHome [has changed the way platform is infomed](https://github.com/esphome/esphome/pull/8118) this PR aims to fix the config to comply with the new format